### PR TITLE
Add null checks to addEventLIstener

### DIFF
--- a/spongeapi.js
+++ b/spongeapi.js
@@ -312,8 +312,10 @@ handleSetupResponse = function(message) {
   spongeapi.initComplete = true;
 }
 window.addEventListener('message', function(event) {
-  var message = event.data;
-  if (message) {
-  eval(message.callback)(message.data);
+  if (event){
+    var message = event.data;
+    if (message && message.callback) {
+      eval(message.callback)(message.data);
+    }
   }
 });


### PR DESCRIPTION
Ran into this at work where callback was undefined. Adding in a check for the case when callback and/or event is undefined.
